### PR TITLE
DEVOPS-2006: Add support to publish to jobvite nexus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,30 +75,17 @@
     <!-- For Maven distribution -->
     <distributionManagement>
       <snapshotRepository>
-        <id>ossrh</id>
-        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        <id>jv-maven-repo-snapshot</id>
+        <url>https://nexus.dev.jobvite.net/repository/maven-jobvite-snapshot/</url>
       </snapshotRepository>
-<!--      <repository>
-        <id>ossrh</id>
-        <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-      </repository>-->
+      <repository>
+        <id>jv-maven-repo-release</id>
+        <url>https://nexus.dev.jobvite.net/repository/maven-jobvite-release/</url>
+      </repository>
     </distributionManagement>
 
     <build>
       <plugins>
-        <!-- Nexus Staging -->
-        <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.7</version>
-          <extensions>true</extensions>
-          <configuration>
-            <serverId>ossrh</serverId>
-            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-          </configuration>
-        </plugin>
-
         <!-- _____-sources.jar generation -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -134,17 +121,10 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
           <version>1.5</version>
-          <executions>
-            <execution>
-              <id>sign-artifacts</id>
-              <phase>verify</phase>
-              <goals>
-                <goal>sign</goal>
-              </goals>
-            </execution>
-          </executions>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
         </plugin>
       </plugins>
     </build>
-    
 </project>

--- a/settings.xml
+++ b/settings.xml
@@ -1,21 +1,14 @@
 <settings>
   <servers>
     <server>
-      <id>ossrh</id>
-      <username>aioobe</username>
-      <password>[enter sonatype password here]</password>
+      <id>jv-maven-repo-snapshot</id>
+      <username>publish</username>
+      <password>fuzzy_logic#</password>
+    </server>
+    <server>
+      <id>jv-maven-repo-release</id>
+      <username>publish</username>
+      <password>fuzzy_logic#</password>
     </server>
   </servers>
-  <profiles>
-    <profile>
-      <id>ossrh</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <gpg.executable>gpg2</gpg.executable>
-        <gpg.passphrase>the_pass_phrase</gpg.passphrase>
-      </properties>
-    </profile>
-  </profiles>
 </settings>

--- a/settings.xml
+++ b/settings.xml
@@ -3,12 +3,12 @@
     <server>
       <id>jv-maven-repo-snapshot</id>
       <username>publish</username>
-      <password>fuzzy_logic#</password>
+      <password>ojyRbGe3RFseDBSDKcR3W2n3RPon5X4QhCDetJBEumiYqjWspuyZk75nRTBn434B</password>
     </server>
     <server>
       <id>jv-maven-repo-release</id>
       <username>publish</username>
-      <password>fuzzy_logic#</password>
+      <password>ojyRbGe3RFseDBSDKcR3W2n3RPon5X4QhCDetJBEumiYqjWspuyZk75nRTBn434B</password>
     </server>
   </servers>
 </settings>


### PR DESCRIPTION
Why do we need this change?
----
Canvas requires a modified version of the cloudconvert jar. Currently it
relies upon jitpack to do the build and publish of the artifact. Rather
then relying upon an external party with access to some code we'd rather
build it ourselves and upload to our centralized source for all users to
leverage

What effects does this change have?
----
* Updates distributionManagment to replace oss repository information
  with nexus based repositories for release and snapshot
* Disables signing of the package generation as we don't have a signing
  key that we use for packages for now
* Replaces credentials with a publishing user and password that will
  allow upload to nexus